### PR TITLE
xbox fix : reverse condition for modelName hack

### DIFF
--- a/coherence/upnp/devices/media_server.py
+++ b/coherence/upnp/devices/media_server.py
@@ -451,17 +451,14 @@ class RootDeviceXML(static.Data):
 
     if xbox_hack:
       etree.SubElement(d, 'friendlyName').text = friendly_name + ' : 1 : Windows Media Connect'
+      etree.SubElement(d, 'modelName').text = 'Windows Media Connect'
     else:
       etree.SubElement(d, 'friendlyName').text = friendly_name
+      etree.SubElement(d, 'modelName').text = __service_name__
 
     etree.SubElement(d, 'manufacturer').text = 'beebits.net'
     etree.SubElement(d, 'manufacturerURL').text = __url__
     etree.SubElement(d, 'modelDescription').text = __service_name__
-
-    if not xbox_hack:
-      etree.SubElement(d, 'modelName').text = 'Windows Media Connect'
-    else:
-      etree.SubElement(d, 'modelName').text = __service_name__
 
     etree.SubElement(d, 'modelNumber').text = __version__
     etree.SubElement(d, 'modelURL').text = __url__


### PR DESCRIPTION
Current version of Cohen fails to be discovered by xbox 360 dlna client. Pull request reverse a condition which disabled custom behavior when Cohen is discovered by microsoft dlna client.

Tested with XBox 360 (modification allows Cohen discovery) and Samsung AllShare (no regression).
