### PR TITLE
LazyContainer : first get_children call does not honor start / request_count parameters

### DIFF
--- a/coherence/backend.py
+++ b/coherence/backend.py
@@ -556,9 +556,8 @@ class LazyContainer(Container):
 
         if self.childrenRetrievingNeeded is True:
             #print "children Retrieving IS Needed (offset is %d)" % start
-            return self.retrieve_all_children()
-        else:
-            return Container.get_children(self, start, request_count)
+            self.retrieve_all_children()
+        Container.get_children(self, start, request_count)
 
 ROOT_CONTAINER_ID = 0
 SEED_ITEM_ID = 1000


### PR DESCRIPTION
If children retrieving is triggered, full children collection is returned, so start / request_count is ignored.
It can break children retrieving as soap request RequestedCount is ignored.
For Samsung AllShare on 2012 Samsung TV, client requests to browse direct children with a RequestedCount of 1. As all results are sent back by soap response, dlna client seems to be lost, and displays no result !

Patch triggers children retrieving if needed, but use common path to return results (and so allways honor start/request_count parameters). Tested successfully with a backend I am currently developping and various dlna clients (xbox 360 / samsung tv / android clients) 
