### PR TITLE
Louie version fix

### DIFF
--- a/coherence/backends/fs_storage.py
+++ b/coherence/backends/fs_storage.py
@@ -646,7 +646,7 @@ class FSStore(BackendStore):
             container = containers.pop()
             try:
                 self.debug('adding %r', container.location)
-                for child in container.location.children():
+                for child in sorted(container.location.children()):
                     if ignore_file_pattern.match(child.basename()) != None:
                         continue
                     new_container = self.append(child.path, container)

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ DOCPAGES = (
 
 deps = [
   'ConfigObj >= 4.3',
-  'Twisted >= 14.0,<19.7',
+  'Twisted >= 14.0',
   'zope.interface',
   'louie < 2',
   'livestreamer',

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ deps = [
   'ConfigObj >= 4.3',
   'Twisted >= 14.0',
   'zope.interface',
-  'louie',
+  'louie < 2',
   'livestreamer',
   'lxml',
   'python-dateutil',

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ DOCPAGES = (
 
 deps = [
   'ConfigObj >= 4.3',
-  'Twisted >= 14.0',
+  'Twisted >= 14.0,<19.7',
   'zope.interface',
   'louie < 2',
   'livestreamer',


### PR DESCRIPTION
The main issue is that the new Louie 2.0 doesn't support Python 2 (upstream bug filed about the metadata at https://github.com/11craft/louie/issues/12) but then I ran into another issue where the ordering of the filesystem paths could affect the FSStore tests, so fixed that as well.